### PR TITLE
Adding Bundle.properties to built JAR file via maven-resources-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,9 @@
 	<properties>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<!-- Name of bundle properties files, need packaging with JAR. -->
+		<resources.bundle_properties.filename>Bundle.properties</resources.bundle_properties.filename>
 	</properties>
 
 	<dependencies>
@@ -60,6 +63,30 @@
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.7</version>
+				<executions>
+					<execution>
+						<id>copy Bundle.properties files</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/classes/</outputDirectory>
+							<resources>
+								<resource>
+									<directory>${project.basedir}/src/main/java</directory>
+									<includes>
+										<include>**/${resources.bundle_properties.filename}</include>
+									</includes>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>com.agilejava.docbkx</groupId>
 				<artifactId>docbkx-maven-plugin</artifactId>


### PR DESCRIPTION
When attempting to reference the jalopy2 code from a mwe2 build engine, it complains that the Bundle.properties files are not present. 

Looking at the source tree, they are present under src/main/java, they are simply not packaged-up into the JAR during the build process.

I have included these in the package by introducing an additional plugin execution during the prepare-package phase to specifically copy over these files.
